### PR TITLE
update to pull closest next future launch

### DIFF
--- a/src/pages/spacex/__snapshots__/index.test.js.snap
+++ b/src/pages/spacex/__snapshots__/index.test.js.snap
@@ -37,25 +37,13 @@ exports[`SpaceX Component when \`useFetch\` returns data displays data 1`] = `
       class="spacex-mega"
     >
       <div>
-        357674
+        366
          
         days
          
       </div>
       <div>
-        10
-         
-        hours
-         
-      </div>
-      <div>
-        21
-         
-        minutes
-         
-      </div>
-      <div>
-        47
+        0
          
         seconds
          
@@ -71,7 +59,7 @@ exports[`SpaceX Component when \`useFetch\` returns data displays data 1`] = `
         When:
       </label>
       <span>
-        Wednesday, January 1, 3000, 12:00 AM
+        Friday, January 1, 2021, 12:00 AM
       </span>
     </div>
     <div

--- a/src/pages/spacex/__snapshots__/index.test.js.snap
+++ b/src/pages/spacex/__snapshots__/index.test.js.snap
@@ -35,9 +35,34 @@ exports[`SpaceX Component when \`useFetch\` returns data displays data 1`] = `
     </h2>
     <div
       class="spacex-mega"
-    />
+    >
+      <div>
+        357674
+         
+        days
+         
+      </div>
+      <div>
+        10
+         
+        hours
+         
+      </div>
+      <div>
+        21
+         
+        minutes
+         
+      </div>
+      <div>
+        47
+         
+        seconds
+         
+      </div>
+    </div>
     <h3>
-      mission_name
+      mission_name_future
     </h3>
     <div
       class="spacex-item"
@@ -46,7 +71,7 @@ exports[`SpaceX Component when \`useFetch\` returns data displays data 1`] = `
         When:
       </label>
       <span>
-        Saturday, January 1, 2000, 12:00 AM
+        Wednesday, January 1, 3000, 12:00 AM
       </span>
     </div>
     <div
@@ -56,7 +81,7 @@ exports[`SpaceX Component when \`useFetch\` returns data displays data 1`] = `
         Rocket:
       </label>
       <span>
-        rocket_name
+        rocket_name_future
       </span>
     </div>
     <div
@@ -66,13 +91,13 @@ exports[`SpaceX Component when \`useFetch\` returns data displays data 1`] = `
         Launch Site:
       </label>
       <span>
-        site_name_long
+        site_name_long_future
       </span>
     </div>
     <div
       class="spacex-details"
     >
-      details
+      future details
     </div>
   </section>
 </div>

--- a/src/pages/spacex/index.js
+++ b/src/pages/spacex/index.js
@@ -9,8 +9,16 @@ import Loading from "../../components/loading";
 
 const SpaceX = () => {
   const { loading, data: upcomingLaunch } = useFetch(
-    `https://api.spacexdata.com/v3/launches/upcoming?limit=1`
+    `https://api.spacexdata.com/v3/launches/upcoming?limit=2`
   );
+
+  const futureLaunchIndex = () => {
+    if (!loading && upcomingLaunch.length) {
+      return new Date(upcomingLaunch[0]["launch_date_utc"]) < new Date()
+        ? 1
+        : 0;
+    }
+  };
 
   const calcTimeToLaunch = () => {
     let timeLeft = {};
@@ -19,9 +27,10 @@ const SpaceX = () => {
         return timeLeft;
       }
 
-      if (upcomingLaunch[0]) {
+      if (upcomingLaunch[futureLaunchIndex()]) {
         const difference =
-          +new Date(upcomingLaunch[0]["launch_date_utc"]) - +new Date();
+          +new Date(upcomingLaunch[futureLaunchIndex()]["launch_date_utc"]) -
+          +new Date();
 
         if (difference > 0) {
           timeLeft = {
@@ -58,6 +67,48 @@ const SpaceX = () => {
     );
   });
 
+  const launchDetails = () => {
+    if (loading) {
+      return null;
+    }
+
+    const launch = upcomingLaunch[futureLaunchIndex()];
+    const options = {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+    };
+
+    const launchDate = new Date(launch["launch_date_utc"]).toLocaleString(
+      "en-US",
+      options
+    );
+    return (
+      <Fragment key={launch["mission_name"]}>
+        <div className="spacex-mega">{timerComponents}</div>
+
+        <h3>{launch["mission_name"]}</h3>
+        <div className="spacex-item">
+          <label>When:</label>
+          <span>{launchDate}</span>
+        </div>
+        <div className="spacex-item">
+          <label>Rocket:</label>
+          <span>{launch["rocket"]["rocket_name"]}</span>
+        </div>
+        <div className="spacex-item">
+          <label>Launch Site:</label>
+          <span>{launch["launch_site"]["site_name_long"]}</span>
+        </div>
+
+        <div className="spacex-details">{launch["details"]}</div>
+      </Fragment>
+    );
+  };
+
   return (
     <section className="spacex-container">
       <h2>Next Space X Launch</h2>
@@ -66,45 +117,7 @@ const SpaceX = () => {
         <Error componentName="SpaceX" />
       )}
 
-      {upcomingLaunch && upcomingLaunch.length && (
-        <>
-          {upcomingLaunch.map((launch) => {
-            const options = {
-              weekday: "long",
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-              hour: "numeric",
-              minute: "numeric",
-            };
-
-            const launchDate = new Date(
-              launch["launch_date_utc"]
-            ).toLocaleString("en-US", options);
-            return (
-              <Fragment key={launch["mission_name"]}>
-                <div className="spacex-mega">{timerComponents}</div>
-
-                <h3>{launch["mission_name"]}</h3>
-                <div className="spacex-item">
-                  <label>When:</label>
-                  <span>{launchDate}</span>
-                </div>
-                <div className="spacex-item">
-                  <label>Rocket:</label>
-                  <span>{launch["rocket"]["rocket_name"]}</span>
-                </div>
-                <div className="spacex-item">
-                  <label>Launch Site:</label>
-                  <span>{launch["launch_site"]["site_name_long"]}</span>
-                </div>
-
-                <div className="spacex-details">{launch["details"]}</div>
-              </Fragment>
-            );
-          })}
-        </>
-      )}
+      {upcomingLaunch && upcomingLaunch.length && launchDetails()}
     </section>
   );
 };

--- a/src/pages/spacex/index.js
+++ b/src/pages/spacex/index.js
@@ -14,9 +14,7 @@ const SpaceX = () => {
 
   const futureLaunchIndex = () => {
     if (!loading && upcomingLaunch.length) {
-      return new Date(upcomingLaunch[0]["launch_date_utc"]) < new Date()
-        ? 1
-        : 0;
+      return upcomingLaunch[0]["launch_date_unix"] < Date.now() / 1000 ? 1 : 0;
     }
   };
 
@@ -29,15 +27,15 @@ const SpaceX = () => {
 
       if (upcomingLaunch[futureLaunchIndex()]) {
         const difference =
-          +new Date(upcomingLaunch[futureLaunchIndex()]["launch_date_utc"]) -
-          +new Date();
+          upcomingLaunch[futureLaunchIndex()]["launch_date_unix"] -
+          Date.now() / 1000;
 
         if (difference > 0) {
           timeLeft = {
-            days: Math.floor(difference / (1000 * 60 * 60 * 24)),
-            hours: Math.floor((difference / (1000 * 60 * 60)) % 24),
-            minutes: Math.floor((difference / 1000 / 60) % 60),
-            seconds: Math.floor((difference / 1000) % 60),
+            days: Math.floor(difference / (60 * 60 * 24)),
+            hours: Math.floor((difference / (60 * 60)) % 24),
+            minutes: Math.floor((difference / 60) % 60),
+            seconds: Math.floor(difference % 60),
           };
         }
       }

--- a/src/pages/spacex/index.test.js
+++ b/src/pages/spacex/index.test.js
@@ -28,6 +28,11 @@ describe("SpaceX Component", () => {
   });
 
   describe("when `useFetch` returns data", () => {
+    beforeEach(() => {
+      const mockDate = new Date("01-01-2020");
+      global.Date.now = jest.fn(() => mockDate);
+    });
+
     it("displays data", () => {
       useFetch.mockReturnValue({
         loading: false,
@@ -35,14 +40,16 @@ describe("SpaceX Component", () => {
           {
             mission_name: "mission_name",
             details: "details",
-            launch_date_utc: new Date("01-01-2000"),
+            launch_date_unix: new Date("01-01-2019").valueOf() / 1000,
+            launch_date_utc: new Date("01-01-2019"),
             rocket: { rocket_name: "rocket_name" },
             launch_site: { site_name_long: "site_name_long" },
           },
           {
             mission_name: "mission_name_future",
             details: "future details",
-            launch_date_utc: new Date("01-01-3000"),
+            launch_date_unix: new Date("01-01-2021").valueOf() / 1000,
+            launch_date_utc: new Date("01-01-2021"),
             rocket: { rocket_name: "rocket_name_future" },
             launch_site: { site_name_long: "site_name_long_future" },
           },

--- a/src/pages/spacex/index.test.js
+++ b/src/pages/spacex/index.test.js
@@ -39,6 +39,13 @@ describe("SpaceX Component", () => {
             rocket: { rocket_name: "rocket_name" },
             launch_site: { site_name_long: "site_name_long" },
           },
+          {
+            mission_name: "mission_name_future",
+            details: "future details",
+            launch_date_utc: new Date("01-01-3000"),
+            rocket: { rocket_name: "rocket_name_future" },
+            launch_site: { site_name_long: "site_name_long_future" },
+          },
         ],
       });
 


### PR DESCRIPTION
Sometimes the launches get delayed and the API doesn't reflect that with the upcoming launch results. This change will pull back two results and use the closest future launch date for all data and the countdown.