### PR TITLE
remove babel devdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     ]
   },
   "devDependencies": {
-    "@babel/compat-data": "^7.12.7",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/react-hooks": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/compat-data@^7.12.7", "@babel/compat-data@^7.8.6", "@babel/compat-data@^7.9.0":
+"@babel/compat-data@^7.8.6", "@babel/compat-data@^7.9.0":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.7.tgz#9329b4782a7d6bbd7eef57e11addf91ee3ef1e41"
   integrity sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==


### PR DESCRIPTION
I think I added babel because of something with create react app. maybe like this: https://github.com/babel/babel/issues/11292

This was added with https://github.com/jsegal205/jimsegal-projects/pull/89/commits/77259113d63350c63d562bcd90badf5b5a27016f

I remember this happening but thought I documented better about this breaking. guess not. 