### PR TITLE
remove explicit dep to mimimist, use package.json resolution to bump …

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@sentry/react": "^6.19.4",
     "@sentry/tracing": "^6.19.4",
     "axios": "^0.26.1",
-    "minimist": "^1.2.2",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-ga": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8189,10 +8189,10 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.2, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
…minimist version

yarn doesn't have something similar to `npm audit fix` so I added a resolutions key to package json to update the version to cover the CVE found in minimist. 

https://alfilatov.com/posts/how-to-fix-security-vulnerabilities-in-npm-yarn-dependencies/